### PR TITLE
Fix perl warnings when running with defaults on Linux on a machine with no battery

### DIFF
--- a/rainbarf
+++ b/rainbarf
@@ -202,10 +202,10 @@ sub battery {
                 }
                 close $fh;
             }
-        }
 
-        $charging = $battery{charging_state} ne q(discharging);
-        $battery = eval { $battery{remaining_capacity} / $battery{last_full_capacity} };
+            $charging = $battery{charging_state} ne q(discharging);
+            $battery = eval { $battery{remaining_capacity} / $battery{last_full_capacity} };
+        }
     }
 
     if (defined $battery) {


### PR DESCRIPTION
Currently on Linux desktop machine which has ACPI support thus /proc/acpi/battery exists but no BAT\* files there since no battery on the machine, rainbarf will output some warnings. This change will do the battery stats calculation only if BAT\* files are really available thus avoiding the warnings.

(12:54:35)(tj@ganga)(~/prj/rainbarf)$ ./rainbarf 
Use of uninitialized value $battery{"charging_state"} in string ne at ./rainbarf line 207.
Use of uninitialized value in division (/) at ./rainbarf line 208.
Use of uninitialized value in division (/) at ./rainbarf line 208.
