### PR TITLE
Adding support for batteries without energy_now and energy_full.

### DIFF
--- a/rainbarf
+++ b/rainbarf
@@ -384,8 +384,8 @@ sub battery {
         my ($uevent, %battery) = ('');
         if (grep {
                 -d $_
-                and -e qq($_/energy_full)
-                and -e qq($_/energy_now)
+                and ( ( -e qq($_/energy_full) and -e qq($_/energy_now) ) or
+                      ( -e qq($_/charge_now) and -e qq($_/current_now) ) )
                 and -e ($uevent = qq($_/uevent))
             } sort glob q(/sys/class/power_supply/BAT[0-9])
         ) {
@@ -401,10 +401,13 @@ sub battery {
             close $fh;
 
             $charging = $battery{status} ne q(Discharging);
-            $time = eval { ($battery{energy_now} * 60 / $battery{power_now}) }
-                if not $charging
-                and defined $battery{power_now}
-                and $battery{power_now} =~ /^\d+$/x;
+            if (not $charging) {
+                if (defined $battery{power_now} and $battery{power_now} =~ /^\d+$/x) {
+                    $time = eval { ($battery{energy_now} * 60 / $battery{power_now}) }
+                } elsif (defined $battery{charge_now} and $battery{charge_now} =~ /^\d+$/x) {
+                    $time = eval { (60 * ($battery{charge_now} / 1000) / ($battery{current_now} / 1000)) }
+                }
+            }
             $battery = $battery{capacity} / 100;
         }
     }


### PR DESCRIPTION
Apparently not all systems have these values in `/sys/class/power_supply`, so the battery meter doesn't work. In the ACPI source code they use `current_now` and `charge_now` to calculate time remaining if other values aren't available, so I just ported that calculation and set it up to use that as a fallback.

I don't actually have a system where `energy_now` and `energy_full` exist, so I'd suggest testing this code on such a system to make sure it still works as expected. I'm not 100% confident in my Perl grep skills :neutral_face:.
